### PR TITLE
[resotometrics][fix] move Prometheus annotations

### DIFF
--- a/charts/resoto/Chart.yaml
+++ b/charts/resoto/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.3.3
+version: 0.3.4
 
 appVersion: "2.4.0"
 maintainers:

--- a/charts/resoto/README.md
+++ b/charts/resoto/README.md
@@ -1,6 +1,6 @@
 # resoto
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/resoto/templates/resotometrics/deployment.yaml
+++ b/charts/resoto/templates/resotometrics/deployment.yaml
@@ -5,12 +5,6 @@ metadata:
   labels:
     resoto: metrics
     {{- include "resoto.labels" . | nindent 4 }}
-  {{- if not .Values.resotometrics.serviceMonitor.enabled }}
-  annotations:
-    prometheus.io/scrape: 'true'
-    prometheus.io/path: '/metrics'
-    prometheus.io/port: '9955'
-  {{- end }}
 spec:
   replicas: 1
   selector:

--- a/charts/resoto/templates/resotometrics/service.yaml
+++ b/charts/resoto/templates/resotometrics/service.yaml
@@ -5,6 +5,13 @@ metadata:
   labels:
     resoto: metrics
     {{- include "resoto.labels" . | nindent 4 }}
+  {{- if not .Values.resotometrics.serviceMonitor.enabled }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: '/metrics'
+    prometheus.io/port: '9955'
+    prometheus.io/scheme: 'https'
+  {{- end }}
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
This PR moves Prometheus annotations for `resotometrics` from the deployment to the service which is where default Prometheus looks for them (`kubernetes-service-endpoints` and `kubernetes-pods`). Also adds `https` scheme which is now default for all Resoto services.
