### PR TITLE
Add README to repo root

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
 
-
 jobs:
   package-release:
     permissions:
@@ -32,7 +31,7 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.0
         with:
-          charts_dir: charts
-          charts_repo_url: https://helm.resoto.com
+          charts_dir: someengineering
+          charts_repo_url: https://helm.some.engineering
         env:
-          CR_TOKEN: "${{ secrets.SOME_CI_PAT }}"
+          CR_TOKEN: '${{ secrets.SOME_CI_PAT }}'

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-helm.resoto.com
+helm.some.engineering

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Some Engineering Helm Chart Repository
 
+![](https://user-images.githubusercontent.com/2124094/164599444-448f92f1-7a73-4a86-a377-bc650f10e756.png)
+
 ## Usage
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ helm repo add someengineering https://helm.some.engineering
 
 ## Contact
 
-Have questions or need help? [Join the Some Engineering Discord server](https://discord.gg/someengineering) or [open a GitHub issue](https://github.com/someengineering/helm-charts/issues/new).
+Have questions or need help? [Join us in the Some Engineering Discord server](https://discord.gg/someengineering) or [open a GitHub issue](https://github.com/someengineering/helm-charts/issues/new).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Some Engineering Helm Chart Repository
+
+## Usage
+
+```bash
+$ helm repo add resoto https://helm.resoto.com
+```
+
+## Charts
+
+### `resoto`
+
+- [Chart documentation](./someengineering/resoto/README.md)
+- [Installation instructions](https://resoto.com/docs/getting-started/install-resoto/kubernetes)
+
+## Contact
+
+Have questions or need help? [Join the Some Engineering Discord server](https://discord.gg/someengineering) or [open a GitHub issue](https://github.com/someengineering/helm-charts/issues/new).
+
+## License
+
+```
+Copyright 2022 Some Engineering Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```bash
-$ helm repo add resoto https://helm.resoto.com
+$ helm repo add someengineering https://helm.some.engineering
 ```
 
 ## Charts

--- a/index.html
+++ b/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://github.com/someengineering/helm-charts</title>
+<meta http-equiv="refresh" content="0; URL=https://github.com/someengineering/helm-charts">
+<link rel="canonical" href="https://github.com/someengineering/helm-charts">


### PR DESCRIPTION
Adds `README.md` with some basic information/links. Also adds a redirect from the root of the chart repository URL (https://helm.resoto.com) to redirect to this GitHub repository.

@aquamatthias Since this is the Some Engineering chart repository and not the Resoto chart repository, should we change the CNAME?
- Would need @lloesche to configure the subdomain `helm.some.engineering`. We'd want to set up a redirect from `helm.resoto.com` as well to keep existing setups working.
- Also would need to update the `README.md` in this PR as well as the Kubernetes install docs on resoto.com.