### PR TITLE
chore: bump appVersion to 2.4.2

### DIFF
--- a/someengineering/resoto/Chart.yaml
+++ b/someengineering/resoto/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: resoto
 description: A Helm chart for Kubernetes
 type: application
-version: 0.3.10
-appVersion: "2.4.1"
+version: 0.3.11
+appVersion: "2.4.2"
 maintainers:
   - name: kushthedude
   - name: aquamatthias
@@ -11,12 +11,12 @@ maintainers:
 icon: https://cdn.some.engineering/assets/resoto-logos/resoto-logo.svg
 home: https://resoto.com
 dependencies:
-   - name: common
-     alias: common
-     repository: https://charts.bitnami.com/bitnami
-     tags:
-       - bitnami-common
-     version: 2.0.2
+  - name: common
+    alias: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 2.0.2
 sources:
   - https://github.com/someengineering/resoto
 keywords:

--- a/someengineering/resoto/README.md
+++ b/someengineering/resoto/README.md
@@ -1,6 +1,6 @@
 # resoto
 
-![Version: 0.3.10](https://img.shields.io/badge/Version-0.3.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
+![Version: 0.3.11](https://img.shields.io/badge/Version-0.3.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 


### PR DESCRIPTION
Bumps Resoto version to [2.4.2](https://github.com/someengineering/resoto/releases/tag/2.4.2).