### PR TITLE
Add installation flag to resotocore env

### DIFF
--- a/someengineering/resoto/templates/resotocore/deployment.yaml
+++ b/someengineering/resoto/templates/resotocore/deployment.yaml
@@ -77,7 +77,7 @@ spec:
           - name: HELM_APP_VERSION
             value: {{ .Chart.AppVersion }}
           - name: HELM_INSTALL_FLAG
-            value: true
+            value: "true"
           ports:
             - name: api
               containerPort: 8900

--- a/someengineering/resoto/templates/resotocore/deployment.yaml
+++ b/someengineering/resoto/templates/resotocore/deployment.yaml
@@ -76,6 +76,8 @@ spec:
             value: {{ .Chart.Version }}
           - name: HELM_APP_VERSION
             value: {{ .Chart.AppVersion }}
+          - name: HELM_INSTALL_FLAG
+            value: true
           ports:
             - name: api
               containerPort: 8900


### PR DESCRIPTION
Adds `HELM_INSTALL_FLAG = true` to the environment, to be used for analytics purposes