### PR TITLE
helm install fails with resotocore.ingress.enabled

### DIFF
--- a/someengineering/resoto/Chart.yaml
+++ b/someengineering/resoto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: resoto
 description: A Helm chart for Kubernetes
 type: application
-version: 0.6.5
+version: 0.6.6
 appVersion: "3.0.4"
 maintainers:
   - name: kushthedude

--- a/someengineering/resoto/README.md
+++ b/someengineering/resoto/README.md
@@ -1,6 +1,6 @@
 # resoto
 
-![Version: 0.6.5](https://img.shields.io/badge/Version-0.6.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.4](https://img.shields.io/badge/AppVersion-3.0.4-informational?style=flat-square)
+![Version: 0.6.6](https://img.shields.io/badge/Version-0.6.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.4](https://img.shields.io/badge/AppVersion-3.0.4-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/someengineering/resoto/templates/resotocore/ingress.yaml
+++ b/someengineering/resoto/templates/resotocore/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "resoto.fullname" . -}}
 {{- $fullName = (printf "%s%s" $fullName  "-resotocore") }}
 {{- $svcPort := .Values.resotocore.service.port -}}
-{{- if include "common.ingress.supportsIngressClassname" }}
+{{- if include "common.ingress.supportsIngressClassname" . }}
   {{- if not (hasKey .Values.resotocore.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.resotocore.ingress.annotations "kubernetes.io/ingress.class" .Values.resotocore.ingress.className}}
   {{- end }}
@@ -38,7 +38,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if include "common.ingress.supportsPathType" }}
+            {{- if include "common.ingress.supportsPathType" . }}
             pathType: {{ .pathType }}
             {{- end }}
             backend:


### PR DESCRIPTION
using this example values.yaml
```
#...
resotocore:
  ingress:
          enabled: true
          annotations:
            kubernetes.io/ingress.class: kommander-traefik
          hosts:
            - paths:
                - path: "/resoto"
                  pathType: ImplementationSpecific
# ...
```

we get an helm error message:
```
template: resoto/templates/resotocore/ingress.yaml:5:7: executing "resoto/templates/resotocore/ingress.yaml" at <include>: wrong number of args for include: want 2 got 1
```

this is due to `if include common.ingress.supportsIngressClassname` and `if include common.ingress.supportsPathType`: 
`common.ingress.supportsIngressClassname` and `common.ingress.supportsPathType` needs context as input see: https://artifacthub.io/packages/helm/bitnami/common#ingress 