### PR TITLE
Fix - error when using resotocore.extraEnv

### DIFF
--- a/someengineering/resoto/Chart.yaml
+++ b/someengineering/resoto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: resoto
 description: A Helm chart for Kubernetes
 type: application
-version: 0.6.6
+version: 0.6.7
 appVersion: "3.0.4"
 maintainers:
   - name: kushthedude

--- a/someengineering/resoto/README.md
+++ b/someengineering/resoto/README.md
@@ -1,6 +1,6 @@
 # resoto
 
-![Version: 0.6.6](https://img.shields.io/badge/Version-0.6.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.4](https://img.shields.io/badge/AppVersion-3.0.4-informational?style=flat-square)
+![Version: 0.6.7](https://img.shields.io/badge/Version-0.6.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.4](https://img.shields.io/badge/AppVersion-3.0.4-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/someengineering/resoto/templates/resotocore/deployment.yaml
+++ b/someengineering/resoto/templates/resotocore/deployment.yaml
@@ -74,7 +74,7 @@ spec:
                 name: {{ include "resoto.fullname" . }}-psk
                 key: "psk"
           {{- if .Values.resotocore.extraEnv }}
-          {{- toYaml .Values.resotocore.extraEnv | nindent 12 }}
+          {{- toYaml .Values.resotocore.extraEnv | nindent 10 }}
           {{- end }}
           - name: HELM_VERSION
             value: {{ .Chart.Version }}


### PR DESCRIPTION
`resotocore.extraEnv` was using a wrong indentation so whenever the variable was not empty an parsing error occurs