### PR TITLE
chore: bump appVersion to 3.1.0

### DIFF
--- a/someengineering/resoto/Chart.yaml
+++ b/someengineering/resoto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: resoto
 description: A Helm chart for Kubernetes
 type: application
-version: 0.6.10
+version: 0.6.11
 appVersion: "3.1.0"
 maintainers:
   - name: kushthedude

--- a/someengineering/resoto/README.md
+++ b/someengineering/resoto/README.md
@@ -1,6 +1,6 @@
 # resoto
 
-![Version: 0.6.10](https://img.shields.io/badge/Version-0.6.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.0](https://img.shields.io/badge/AppVersion-3.1.0-informational?style=flat-square)
+![Version: 0.6.11](https://img.shields.io/badge/Version-0.6.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.0](https://img.shields.io/badge/AppVersion-3.1.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 


### PR DESCRIPTION
Bumps Resoto version to [3.1.0](https://github.com/someengineering/resoto/releases/tag/3.1.0).