### PR TITLE
chore: bump appVersion to 3.2.1

### DIFF
--- a/someengineering/resoto/Chart.yaml
+++ b/someengineering/resoto/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: resoto
 description: A Helm chart for Kubernetes
 type: application
-version: 0.6.12
-appVersion: "3.2.0"
+version: 0.6.13
+appVersion: "3.2.1"
 maintainers:
   - name: kushthedude
   - name: aquamatthias

--- a/someengineering/resoto/README.md
+++ b/someengineering/resoto/README.md
@@ -1,6 +1,6 @@
 # resoto
 
-![Version: 0.6.12](https://img.shields.io/badge/Version-0.6.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.2.0](https://img.shields.io/badge/AppVersion-3.2.0-informational?style=flat-square)
+![Version: 0.6.13](https://img.shields.io/badge/Version-0.6.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.2.1](https://img.shields.io/badge/AppVersion-3.2.1-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 


### PR DESCRIPTION
Bumps Resoto version to [3.2.1](https://github.com/someengineering/resoto/releases/tag/3.2.1).