### PR TITLE
chore: bump Resoto appVersion to 3.2.3

### DIFF
--- a/someengineering/resoto/Chart.yaml
+++ b/someengineering/resoto/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: resoto
 description: A Helm chart for Kubernetes
 type: application
-version: 0.6.14
-appVersion: "3.2.2"
+version: 0.6.15
+appVersion: "3.2.3"
 maintainers:
   - name: kushthedude
   - name: aquamatthias

--- a/someengineering/resoto/README.md
+++ b/someengineering/resoto/README.md
@@ -1,6 +1,6 @@
 # resoto
 
-![Version: 0.6.14](https://img.shields.io/badge/Version-0.6.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.2.2](https://img.shields.io/badge/AppVersion-3.2.2-informational?style=flat-square)
+![Version: 0.6.15](https://img.shields.io/badge/Version-0.6.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.2.3](https://img.shields.io/badge/AppVersion-3.2.3-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 


### PR DESCRIPTION
Bumps Resoto version to [3.2.3](https://github.com/someengineering/resoto/releases/tag/3.2.3).