### PR TITLE
chore: bump Resoto appVersion to 3.3.4

### DIFF
--- a/someengineering/resoto/Chart.yaml
+++ b/someengineering/resoto/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: resoto
 description: A Helm chart for Kubernetes
 type: application
-version: 0.7.6
-appVersion: "3.3.3"
+version: 0.7.7
+appVersion: "3.3.4"
 maintainers:
   - name: aquamatthias
     email: "eng@some.engineering"

--- a/someengineering/resoto/README.md
+++ b/someengineering/resoto/README.md
@@ -1,6 +1,6 @@
 # resoto
 
-![Version: 0.7.6](https://img.shields.io/badge/Version-0.7.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.3.3](https://img.shields.io/badge/AppVersion-3.3.3-informational?style=flat-square)
+![Version: 0.7.7](https://img.shields.io/badge/Version-0.7.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.3.4](https://img.shields.io/badge/AppVersion-3.3.4-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 


### PR DESCRIPTION
Bumps Resoto version to [3.3.4](https://github.com/someengineering/resoto/releases/tag/3.3.4).