### PR TITLE
[fix] Ingress scope, bump libs and add annotations for nginx and traefik

### DIFF
--- a/.github/workflows/k8s-build.yaml
+++ b/.github/workflows/k8s-build.yaml
@@ -28,7 +28,7 @@ jobs:
         run: |
           NO_START_KIND=1 CI_ENABLED=1 IMAGE_TAG=edge bash -x ./scripts/setup-kind.sh
           # make sure we get the example collector in a reasonable time.
-          timeout 10m /bin/bash -c "until echo 'workflows run collect; kind' | kubectl exec -i deploy/resoto-resotocore -- resh --stdin | grep example; do sleep 1; done"
+          timeout 10m /bin/bash -c "until echo 'config set resoto.worker resotoworker.collector=[example]; workflows run collect; kind' | kubectl exec -i deploy/resoto-resotocore -- resh --stdin | grep example; do sleep 1; done"
       - name: Debug info on failure
         if: ${{ failure() }}
         run: |

--- a/someengineering/resoto/Chart.yaml
+++ b/someengineering/resoto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: resoto
 description: A Helm chart for Kubernetes
 type: application
-version: 0.7.10
+version: 0.8.0
 appVersion: "3.5.2"
 maintainers:
   - name: aquamatthias
@@ -11,20 +11,20 @@ icon: https://cdn.some.engineering/assets/resoto-logos/resoto-logo.svg
 home: https://resoto.com
 dependencies:
   - name: prometheus
-    version: 18.1.0
+    version: 22.6.6
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus.enabled
   - name: kube-arangodb
     alias: arangodb
     repository: https://arangodb.github.io/kube-arangodb
     condition: arangodb.operator.enabled
-    version: 1.2.24
+    version: 1.2.26
   - name: common
     alias: common
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 2.0.2
+    version: 2.4.0
 sources:
   - https://github.com/someengineering/resoto
 keywords:

--- a/someengineering/resoto/README.md
+++ b/someengineering/resoto/README.md
@@ -1,6 +1,6 @@
 # resoto
 
-![Version: 0.7.10](https://img.shields.io/badge/Version-0.7.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.2](https://img.shields.io/badge/AppVersion-3.5.2-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.2](https://img.shields.io/badge/AppVersion-3.5.2-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/someengineering/resoto/README.md
+++ b/someengineering/resoto/README.md
@@ -20,9 +20,9 @@ A Helm chart for Kubernetes
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://arangodb.github.io/kube-arangodb | arangodb(kube-arangodb) | 1.2.24 |
-| https://charts.bitnami.com/bitnami | common(common) | 2.0.2 |
-| https://prometheus-community.github.io/helm-charts | prometheus | 18.1.0 |
+| https://arangodb.github.io/kube-arangodb | arangodb(kube-arangodb) | 1.2.26 |
+| https://charts.bitnami.com/bitnami | common(common) | 2.4.0 |
+| https://prometheus-community.github.io/helm-charts | prometheus | 22.6.6 |
 
 ## Values
 
@@ -57,7 +57,7 @@ A Helm chart for Kubernetes
 | prometheus.server.retention | string | `"730d"` | Duration to keep time series data. |
 | psk | string | `""` | Defines the private shared key that is used to secure the communication between the components. If the value is not set, a random key is generated. You can get the psk from the secret resoto-psk. |
 | replicaCount | int | `1` | Defines the number of workers to run in parallel. Only increase this number, if you know what you are doing. |
-| resotocore | object | `{"extraArgs":[],"extraEnv":[],"graphdb":{"database":"resoto","passwordSecret":{"key":"password","name":"arango-user"},"server":"http://graph-db-server:8529","username":"resoto"},"image":{"repository":"somecr.io/someengineering/resotocore","tag":""},"ingress":{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"chart-example.local","paths":[{"path":"/","pathType":"ImplementationSpecific"}]}],"tls":[]},"overrides":["resotocore.runtime.start_collect_on_subscriber_connect=true"],"service":{"port":8900,"type":"ClusterIP"}}` | Configuration for ResotoCore. |
+| resotocore | object | `{"extraArgs":[],"extraEnv":[],"graphdb":{"database":"resoto","passwordSecret":{"key":"password","name":"arango-user"},"server":"http://graph-db-server:8529","username":"resoto"},"image":{"repository":"somecr.io/someengineering/resotocore","tag":""},"ingress":{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"chart-example.local","paths":[{"path":"/","pathType":"Prefix"}]}],"tls":[]},"overrides":["resotocore.runtime.start_collect_on_subscriber_connect=true"],"service":{"port":8900,"type":"ClusterIP"}}` | Configuration for ResotoCore. |
 | resotocore.extraArgs | list | `[]` | Use this section to define extra arguments |
 | resotocore.extraEnv | list | `[]` | Use this section to pass extra environment variables |
 | resotocore.graphdb | object | `{"database":"resoto","passwordSecret":{"key":"password","name":"arango-user"},"server":"http://graph-db-server:8529","username":"resoto"}` | This defines the access to the graph database |
@@ -69,10 +69,10 @@ A Helm chart for Kubernetes
 | resotocore.graphdb.username | string | `"resoto"` | The name of the user to connect |
 | resotocore.image.repository | string | `"somecr.io/someengineering/resotocore"` | Image repository |
 | resotocore.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
-| resotocore.ingress.annotations | object | `{}` | All annotations for the ingress. |
+| resotocore.ingress.annotations | object | `{}` | All annotations for the ingress. The backend protocol is HTTPS and the ingress controller needs to be configured for that. nginx: see https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#backend-protocol The annotation "nginx.ingress.kubernetes.io/backend-protocol" is set to "HTTPS" by default. traefik: see https://doc.traefik.io/traefik/routing/providers/kubernetes-ingress/#on-service The annotation "traefik.ingress.kubernetes.io/service.serversscheme" is set to "https" by default. |
 | resotocore.ingress.className | string | `""` | The class of the ingress. If omitted, the configured default ingress class is used. |
 | resotocore.ingress.enabled | bool | `false` | In case you want to expose the service outside the k8s cluster, you can use an ingress. |
-| resotocore.ingress.hosts | list | `[{"host":"chart-example.local","paths":[{"path":"/","pathType":"ImplementationSpecific"}]}]` | Ingress host configuration. |
+| resotocore.ingress.hosts | list | `[{"host":"chart-example.local","paths":[{"path":"/","pathType":"Prefix"}]}]` | Ingress host configuration. |
 | resotocore.overrides | list | `["resotocore.runtime.start_collect_on_subscriber_connect=true"]` | Use this section to override configuration values |
 | resotocore.overrides[0] | string | `"resotocore.runtime.start_collect_on_subscriber_connect=true"` | start a collect cycle automatically when the first collector is connected |
 | resotocore.service.port | int | `8900` | Port of the service. |

--- a/someengineering/resoto/templates/NOTES.txt
+++ b/someengineering/resoto/templates/NOTES.txt
@@ -1,6 +1,7 @@
-1. Get the application URL by running these commands:
+1. Get the application:
 {{- if .Values.resotocore.ingress.enabled }}
 {{- range $host := .Values.resotocore.ingress.hosts }}
+  Make sure you have DNS configured to point to the ingress controller external IP.
   {{- range .paths }}
   http{{ if $.Values.resotocore.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
@@ -23,4 +24,4 @@
   Note that for this to work, the port-forward must remain open.
 {{- end }}
 
-2. Once you have the application URL, you can use resotoshell to connect to it.
+2. Open the application URL in your web browser and continue the installation.

--- a/someengineering/resoto/templates/resotocore/ingress.yaml
+++ b/someengineering/resoto/templates/resotocore/ingress.yaml
@@ -2,9 +2,14 @@
 {{- $fullName := include "resoto.fullname" . -}}
 {{- $fullName = (printf "%s%s" $fullName  "-resotocore") }}
 {{- $svcPort := .Values.resotocore.service.port -}}
-{{- if include "common.ingress.supportsIngressClassname" . }}
-  {{- if not (hasKey .Values.resotocore.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.resotocore.ingress.annotations "kubernetes.io/ingress.class" .Values.resotocore.ingress.className}}
+{{- if contains "nginx" .Values.resotocore.ingress.className }}
+  {{- if not (or (hasKey .Values.resotocore.ingress.annotations "nginx.ingress.kubernetes.io/backend-protocol") (hasKey .Values.resotocore.ingress.annotations "nginx.ingress.kubernetes.io/ssl-passthrough")) }}
+  {{- $_ := set .Values.resotocore.ingress.annotations "nginx.ingress.kubernetes.io/backend-protocol" "HTTPS"}}
+  {{- end }}
+{{- end }}
+{{- if contains "traefik" .Values.resotocore.ingress.className }}
+  {{- if not (hasKey .Values.resotocore.ingress.annotations "traefik.ingress.kubernetes.io/service.serversscheme") }}
+  {{- $_ := set .Values.resotocore.ingress.annotations "traefik.ingress.kubernetes.io/service.serversscheme" "https"}}
   {{- end }}
 {{- end }}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
@@ -38,7 +43,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if include "common.ingress.supportsPathType" . }}
+            {{- if include "common.ingress.supportsPathType" $ }}
             pathType: {{ .pathType }}
             {{- end }}
             backend:
@@ -50,7 +55,7 @@ spec:
               {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
-              {{- end }}
+            {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/someengineering/resoto/values.yaml
+++ b/someengineering/resoto/values.yaml
@@ -45,16 +45,20 @@ resotocore:
     enabled: false
     # -- The class of the ingress. If omitted, the configured default ingress class is used.
     className: ""
-    # -- All annotations for the ingress.
+    # -- All annotations for the ingress. The backend protocol is HTTPS and the ingress controller needs to be configured for that.
+    # nginx: see https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#backend-protocol
+    # The annotation "nginx.ingress.kubernetes.io/backend-protocol" is set to "HTTPS" by default.
+    # traefik: see https://doc.traefik.io/traefik/routing/providers/kubernetes-ingress/#on-service
+    # The annotation "traefik.ingress.kubernetes.io/service.serversscheme" is set to "https" by default.
     annotations: {}
-      #  kubernetes.io/ingress.class: nginx
+    #  kubernetes.io/ingress.class: nginx
     #  kubernetes.io/tls-acme: "true"
     # -- Ingress host configuration.
     hosts:
       - host: chart-example.local
         paths:
           - path: /
-            pathType: ImplementationSpecific
+            pathType: Prefix
     tls: []
 
   # -- This defines the access to the graph database


### PR DESCRIPTION
Fix: Ingress Template used the wrong scope and failed.
Chore: Bump dependencies to latest version
Feat: Add annotations for traefik and nginx to use https as backend communication