### PR TITLE
feat: add `hasKey` check for `ArangoDeployment` `spec`

### DIFF
--- a/someengineering/resoto/Chart.yaml
+++ b/someengineering/resoto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: resoto
 description: A Helm chart for Kubernetes
 type: application
-version: 0.10.4
+version: 0.10.5
 appVersion: "3.8.0"
 maintainers:
   - name: aquamatthias

--- a/someengineering/resoto/README.md
+++ b/someengineering/resoto/README.md
@@ -1,6 +1,6 @@
 # resoto
 
-![Version: 0.10.4](https://img.shields.io/badge/Version-0.10.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.8.0](https://img.shields.io/badge/AppVersion-3.8.0-informational?style=flat-square)
+![Version: 0.10.5](https://img.shields.io/badge/Version-0.10.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.8.0](https://img.shields.io/badge/AppVersion-3.8.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -57,7 +57,7 @@ A Helm chart for Kubernetes
 | prometheus.server.retention | string | `"730d"` | Duration to keep time series data. |
 | psk | string | `""` | Defines the private shared key that is used to secure the communication between the components. If the value is not set, a random key is generated. You can get the psk from the secret resoto-psk. |
 | replicaCount | int | `1` | Defines the number of workers to run in parallel. Only increase this number, if you know what you are doing. |
-| resotocore | object | `{"extraArgs":[],"extraEnv":[],"graphdb":{"database":"resoto","passwordSecret":{"key":"password","name":"arango-user"},"server":"http://graph-db-server:8529","username":"resoto"},"image":{"repository":"somecr.io/someengineering/resotocore","tag":""},"ingress":{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"chart-example.local","paths":[{"path":"/","pathType":"Prefix"}]}],"tls":[],"useHttpsService":false},"overrides":["resotocore.runtime.start_collect_on_subscriber_connect=true"],"resources":{},"service":{"port":8900,"type":"ClusterIP"}}` | Configuration for ResotoCore. |
+| resotocore | object | `{"extraArgs":[],"extraEnv":[],"graphdb":{"database":"resoto","passwordSecret":{"key":"password","name":"arango-user"},"server":"http://graph-db-server:8529","username":"resoto"},"image":{"repository":"somecr.io/someengineering/resotocore","tag":""},"ingress":{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"chart-example.local","paths":[{"path":"/","pathType":"Prefix"}]}],"tls":[],"useHttpsService":false},"overrides":["resotocore.runtime.start_collect_on_subscriber_connect=true"],"resources":{},"service":{"http":{"annotations":{}},"https":{"annotations":{}},"port":8900,"type":"ClusterIP"}}` | Configuration for ResotoCore. |
 | resotocore.extraArgs | list | `[]` | Use this section to define extra arguments |
 | resotocore.extraEnv | list | `[]` | Use this section to pass extra environment variables |
 | resotocore.graphdb | object | `{"database":"resoto","passwordSecret":{"key":"password","name":"arango-user"},"server":"http://graph-db-server:8529","username":"resoto"}` | This defines the access to the graph database |

--- a/someengineering/resoto/templates/arango-db-server.yaml
+++ b/someengineering/resoto/templates/arango-db-server.yaml
@@ -9,10 +9,12 @@ spec:
   {{- with .Values.arangodb.operator.deployment.spec }}
   {{. | toYaml | nindent 2}}
   {{- end}}
+  {{- if not (hasKey .Values.arangodb.operator.deployment.spec (.Values.arangodb.operator.deployment.mode | lower)) }}
   {{ .Values.arangodb.operator.deployment.mode | lower}}:
     volumeClaimTemplate:
       spec: # https://docs.arangodb.com/3.11/deploy/kubernetes/deployment-resource-reference/#specgroupvolumeclaimtemplatespec-persistentvolumeclaimspec
         {{ toYaml .Values.arangodb.persistentVolumeClaimSpec | nindent 8 }}
+  {{- end }}
   externalAccess:
     type: {{ .Values.arangodb.operator.deployment.externalAccessType }}
   tls:

--- a/someengineering/resoto/templates/resotocore/service.yaml
+++ b/someengineering/resoto/templates/resotocore/service.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "resoto.fullname" . }}-resotocore-http
+  {{- with .Values.resotocore.service.http.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     resoto: core
     {{- include "resoto.labels" . | nindent 4 }}
@@ -20,6 +24,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "resoto.fullname" . }}-resotocore
+  {{- with .Values.resotocore.service.https.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     resoto: core
     {{- include "resoto.labels" . | nindent 4 }}

--- a/someengineering/resoto/values.yaml
+++ b/someengineering/resoto/values.yaml
@@ -46,6 +46,10 @@ resotocore:
     # -- Port of the service to expose.
     # Two services will be created: resoto-resotocore:8900 (HTTPS) and resoto-resotocore-http:8900 (HTTP)
     port: 8900
+    http:
+      annotations: {}
+    https:
+      annotations: {}
 
   ingress:
     # -- In case you want to expose the service outside the k8s cluster, you can use an ingress.


### PR DESCRIPTION
so that you can define the whole spec of e.g. the `single` mode.

Otherwise the fallback to only `volumeClaimTemplate.spec` will be counted in.

resolved #103